### PR TITLE
SEAR-538: Search fails if special characters

### DIFF
--- a/jobs-facilities-common/src/main/resources/facility.mapping.json
+++ b/jobs-facilities-common/src/main/resources/facility.mapping.json
@@ -5,6 +5,7 @@
   "properties": {
     "name": {
       "type": "text",
+      "analyzer": "keyword_lowercase",
       "fields": {
         "for_sort": {
           "type": "text",

--- a/jobs-facilities-common/src/main/resources/facility.settings.json
+++ b/jobs-facilities-common/src/main/resources/facility.settings.json
@@ -4,10 +4,11 @@
   "analysis": {
     "analyzer": {
       "keyword_lowercase": {
-        "tokenizer": "keyword",
+        "type": "custom",
         "filter": [
           "lowercase"
-        ]
+        ],
+        "tokenizer": "whitespace"
       }
     }
   }


### PR DESCRIPTION
### JIRA Issue Link
- [Search fails if search term (facility name or facility address) has special characters in it without space in between](https://osi-cwds.atlassian.net/browse/SEAR-538)

### Technical Description
Changed analyzer from keyword to whitespace so that special characters like # would not get ignored by elastic search in facility mapping atttribute name